### PR TITLE
Plug the memory leak for the Disk I/O meter

### DIFF
--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -284,7 +284,7 @@ bool Platform_getDiskIO(DiskIOData* data) {
    if (devstat_checkversion(NULL) < 0)
       return false;
 
-   struct devinfo info = { 0 };
+   static struct devinfo info = { 0 };
    struct statinfo current = { .dinfo = &info };
 
    // get number of devices


### PR DESCRIPTION
There are no functions in `libdevstat` to initialise or clean up memory. The simplest change is to mark the local variable `info` as `static`.